### PR TITLE
rtc: better format the function to get RTC time in microsecond

### DIFF
--- a/bsp_sedi/drivers/rtc/sedi_rtc.c
+++ b/bsp_sedi/drivers/rtc/sedi_rtc.c
@@ -48,7 +48,6 @@ int sedi_rtc_get_capabilities(sedi_rtc_capabilities_t *cap)
 
 int sedi_rtc_init(void)
 {
-	/* SEDI RTC have no alarm and interrupt feature, callback not used */
 	return SEDI_DRIVER_OK;
 }
 
@@ -77,12 +76,9 @@ uint64_t sedi_rtc_get(void)
 	return ((uint64_t)upper << 32U) | lower;
 }
 
-void sedi_rtc_get_us(INOUT uint64_t *us)
+uint64_t sedi_rtc_get_us(void)
 {
-	/* returns the current time in micro seconds. */
-	uint64_t result;
 	uint64_t rtc = sedi_rtc_get();
 
-	result = sedi_rtc_to_us(rtc);
-	*us = result;
+	return sedi_rtc_to_us(rtc);
 }

--- a/bsp_sedi/include/driver/sedi_driver_rtc.h
+++ b/bsp_sedi/include/driver/sedi_driver_rtc.h
@@ -102,11 +102,10 @@ int sedi_rtc_set_power(IN sedi_power_state_t state);
 uint64_t sedi_rtc_get(void);
 
 /*!
- * \brief Get rtc timer in us
- * \param[INOUT] us: Time in us units.
- * \return Time of rtc in us.
+ * \brief Get rtc time in microsecond
+ * \return RTC time in microsecond
  */
-void sedi_rtc_get_us(INOUT uint64_t *us);
+uint64_t sedi_rtc_get_us(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Return the time as function return value instead of as an out parameter for easier usage