### PR TITLE
ish_soc: correct cache line setting as 16 bytes

### DIFF
--- a/bsp_sedi/soc/intel_ish/include/sedi_driver_core.h
+++ b/bsp_sedi/soc/intel_ish/include/sedi_driver_core.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include "sedi_driver_common.h"
 
-#define SEDI_DCACHE_LINE_SIZE ((uint32_t)64)
+#define SEDI_DCACHE_LINE_SIZE ((uint32_t)16)
 
 /*!
  * \brief   Clean & Invalidate D-Cache


### PR DESCRIPTION
It's set with a wrong value before