### PR TITLE
iut: dma: change build condition as CONFIG_DMA_SEDI

### DIFF
--- a/zephyr/iut_test/test_zephyr/CMakeLists.txt
+++ b/zephyr/iut_test/test_zephyr/CMakeLists.txt
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if(CONFIG_DMA)
+if(CONFIG_DMA_SEDI)
   target_sources(app PRIVATE dma/test_dma_m2m.c)
 endif()


### PR DESCRIPTION
won't build DMA test without DMA set as okay in devicetree.