### PR TITLE
pm: skip pmc wake in ipapg entry checking

### DIFF
--- a/bsp_sedi/soc/intel_ish/pm/aon/aon_task.c
+++ b/bsp_sedi/soc/intel_ish/pm/aon/aon_task.c
@@ -523,8 +523,7 @@ static int is_ipapg_allowed(void)
 
 	if (((power_ctrl_enabled & PMU_PCE_PG_ALLOWED) || system_power_state) &&
 	    (((sw_power_req & PMU_SW_PG_REQ_B_VAL) == 0) ||
-	     ((power_ctrl_enabled & PMU_PCE_PMCRE) == 0)) &&
-	    ((power_ctrl_wake & PMU_PMC_PG_WAKE_VAL) == 0))
+	     ((power_ctrl_enabled & PMU_PCE_PMCRE) == 0)))
 		return 1;
 	else
 		return 0;


### PR DESCRIPTION
This patch fixes the chrome KPI test error caused by reset ish and hang in rom. pmc will send pmc falling edge wake to ask ish to go into pg and pmc wake bit is set in the same time. But fw checks pmc wake bit is unset as one of the conditions to decide to enter into pg, this causes ish not go into pg and pmc forcibly reset the ish.