### PR TITLE
actions: upgrade checkout action to v4

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Download Checkpatch Files from Zephyr RTOS
       shell: bash

--- a/.github/workflows/iut_zephyr_build.yml
+++ b/.github/workflows/iut_zephyr_build.yml
@@ -30,7 +30,7 @@ jobs:
           west init
 
       - name: Checkout Intel HAL
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: modules/hal/intel
 

--- a/.github/workflows/sedi_docs_update.yml
+++ b/.github/workflows/sedi_docs_update.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Git Prepare
       shell: bash


### PR DESCRIPTION
To fix the following warinings on runs:
```
Node.js 16 actions are deprecated. Please update the following actions
to use Node.js 20: actions/checkout@v3. For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```