### PR TITLE
iut: add case to test divide0 exception

### DIFF
--- a/zephyr/iut_test/test_zephyr/CMakeLists.txt
+++ b/zephyr/iut_test/test_zephyr/CMakeLists.txt
@@ -14,3 +14,5 @@ endif()
 if(CONFIG_GPIO_SEDI)
   target_sources(app PRIVATE gpio/test_gpio.c)
 endif()
+
+target_sources(app PRIVATE x86/test_fatal.c)

--- a/zephyr/iut_test/test_zephyr/x86/test_fatal.c
+++ b/zephyr/iut_test/test_zephyr/x86/test_fatal.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "iut.h"
+
+int _divider;
+
+static int test_divide0(int argc, char **argv)
+{
+	int num = 1000;
+
+	num /= _divider;
+
+	iut_case_print("no way to come here, %d\n", num);
+	TEST_ASSERT_TRUE(1);
+
+	return IUT_ERR_OK;
+}
+
+DEFINE_IUT_CASE(divide0, fatal, IUT_ATTRI_NONE);


### PR DESCRIPTION
Make sure divide zero exception happens as expected and fatal context is correctly printed out in logs.