### PR TITLE
ish-pm: correctly identify both edge triggered gpio's

### DIFF
--- a/bsp_sedi/soc/intel_ish/pm/ish_pm.c
+++ b/bsp_sedi/soc/intel_ish/pm/ish_pm.c
@@ -104,7 +104,7 @@ static uint32_t convert_both_edge_gpio_to_single_edge(void)
 	 */
 	for (i = 0; i < 32; i++) {
 		if (read32(ISH_GPIO_GIMR) & BIT(i) && read32(ISH_GPIO_GRER) & BIT(i) &&
-		    read32(ISH_GPIO_GFER & BIT(i))) {
+		    read32(ISH_GPIO_GFER) & BIT(i)) {
 			/* Record the pin so we can restore it later */
 			both_edge_pins |= BIT(i);
 


### PR DESCRIPTION
The API convert_both_edge_gpio_to_single_edge() now properly scans through all GPIOs to detect pins that have both-edge trigger mode enabled. The condition check has been updated to ensure accurate identification.

Change-Id: I5084fa9a5accc53aa9bce79f69df73325d1a6115