### PR TITLE
aon: handle reset in aon task

### DIFF
--- a/bsp_sedi/soc/intel_ish/pm/aon/aon_task.c
+++ b/bsp_sedi/soc/intel_ish/pm/aon/aon_task.c
@@ -874,6 +874,9 @@ void ish_aon_main(void)
 
 		aon_share.last_error = AON_SUCCESS;
 
+		if (read32(PMU_RST_PREP) & PMU_RST_PREP_AVAIL)
+			handle_reset(ISH_PM_STATE_RESET_PREP);
+
 		switch (aon_share.pm_state) {
 		case ISH_PM_STATE_D0I2:
 			handle_d0i2();


### PR DESCRIPTION
The handle_reset_in_aontask() API expects the reset to be managed within the AON task. Therefore,
a check has been added at the entry point of the AON task to ensure the reset is handled after
switching.

Change-Id: I1f841e5291d7f85e7a2ce49c559721d52918c645