### PR TITLE
iut: Make shell suspend/resume work with latest Zephyr

### DIFF
--- a/zephyr/iut_test/include/iut_zephyr.h
+++ b/zephyr/iut_test/include/iut_zephyr.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* IUT help functions for Zephyr */
+
+#include <zephyr/kernel.h>
+
+#ifndef _IUT_ZEPHYR_H_
+#define _IUT_ZEPHYR_H_
+
+#ifndef CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
+void iut_shell_suspend(void);
+void iut_shell_resume(void);
+#else
+static inline void iut_shell_suspend(void)
+{
+}
+
+static inline void iut_shell_resume(void)
+{
+}
+#endif
+
+#endif /* _IUT_ZEPHYR_H_ */


### PR DESCRIPTION
They're previously developed against zephyr 3.7 and out of date. Expose them in header file iut_zephyr.h.
They'll be used in incoming pm tests.