### PR TITLE
sedi_stats: Change to use BSD license

### DIFF
--- a/bsp_sedi/include/sedi_stats_utils.h
+++ b/bsp_sedi/include/sedi_stats_utils.h
@@ -1,16 +1,7 @@
 /*
- * Copyright (c) 2023-2025 Intel Corporation. All Rights Reserved.
+ * Copyright (c) 2025 Intel Corporation
  *
- * This software and the related documents are Intel copyrighted materials,
- * and your use of them is governed by the express license under which they
- * were provided to you ("License"). Unless the License provides otherwise,
- * you may not use, modify, copy, publish, distribute, disclose or transmit
- * this software or the related documents without Intel's prior written
- * permission.
- *
- * This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /* {sum, count, max, min, unit string} */


### PR DESCRIPTION
Previously Intel license is used and checked in. Correct it.