### PR TITLE
i2c: fine tune register values to meet the 100 kHz frequency requirement

### DIFF
--- a/bsp_sedi/drivers/i2c/sedi_i2c_dw_apb_200a.c
+++ b/bsp_sedi/drivers/i2c/sedi_i2c_dw_apb_200a.c
@@ -110,7 +110,7 @@ static uint32_t regval_speed[I2C_SPEED_MAX] = {
  * For example, standard mode is 100KHz, 10000ns per period, 5000ns for
  * SCL low & high level.
  */
-#define I2C_SS_SCL_HIGH 4500
+#define I2C_SS_SCL_HIGH 4640
 #define I2C_SS_SCL_LOW 5100
 #define I2C_FS_SCL_HIGH 690
 #define I2C_FS_SCL_LOW 1650


### PR DESCRIPTION
i2c: fine tune register values to meet the 100 kHz frequency requirement

When ISH I2C is configured to standard frequency 100kHz and measured on different WCL RVP and customer reference designs the measured frequency reported is more than 101kHz

The default values of the I2C_SS_SCL_HIGH REG values is increased by 140 to finetune clock frequency to 99.79kHz. This helps generate frequency less than 100kHz by default.

Based on the WCL boards RVP below are the  details on the I2C SCL Clock pulse
tr(raise time)=189.6ns tf(fall time)=48.92ns tHIGH=4.7usec and tLOW=5.124usec. Frequency measured is 99.79kHz

Captures attached:
<img width="1920" height="1079" alt="tHIGH_4 7usec_timing" src="https://github.com/user-attachments/assets/539b9d1e-cd7e-401f-9240-4575c48568ab" />
<img width="1920" height="1079" alt="raisetime_falltime_frequency_measurement" src="https://github.com/user-attachments/assets/a1fd53fd-7bc7-49a5-aaa8-4a467af84d3c" />
<img width="1920" height="1079" alt="tLOW_5 124usec_timing" src="https://github.com/user-attachments/assets/7ae212d8-7b72-4145-ad7e-bfd43887aef0" />
