### PR TITLE
spi: correct spi mode selection logic

### DIFF
--- a/bsp_sedi/drivers/spi/sedi_spi_dw_apb.c
+++ b/bsp_sedi/drivers/spi/sedi_spi_dw_apb.c
@@ -274,8 +274,8 @@ static inline void lld_spi_config_cpol_cpha(sedi_spi_regs_t *spi, int cpol, int 
 	cpha = cpha ? SEDI_RBFV(SPI, CTRLR0, SCPH, SCPH_START) :
 			SEDI_RBFV(SPI, CTRLR0, SCPH, SCPH_MIDDLE);
 
-	SEDI_PREG_RBF_SET(SPI, CTRLR0, SCPH, cpol, &spi->ctrlr0);
-	SEDI_PREG_RBF_SET(SPI, CTRLR0, SCPOL, cpha, &spi->ctrlr0);
+	SEDI_PREG_RBF_SET(SPI, CTRLR0, SCPH, cpha, &spi->ctrlr0);
+	SEDI_PREG_RBF_SET(SPI, CTRLR0, SCPOL, cpol, &spi->ctrlr0);
 }
 
 static inline void lld_spi_config_loopback(sedi_spi_regs_t *spi, int loopback)


### PR DESCRIPTION
Fix by writing each value to its correct register field: cpha -> SCPH (Serial Clock Phase)
cpol -> SCPOL (Serial Clock Polarity)

This bug only affected SPI Mode 1 (CPOL=0, CPHA=1) and Mode 2 (CPOL=1, CPHA=0), which got silently swapped.
Mode 0 and Mode 3 were unaffected as both fields had the same value.