### PR TITLE
i2c: Add SET_BUS_DATA control commands to update default bus timings

### DIFF
--- a/bsp_sedi/drivers/i2c/sedi_i2c_dw_apb_200a.c
+++ b/bsp_sedi/drivers/i2c/sedi_i2c_dw_apb_200a.c
@@ -1126,6 +1126,25 @@ int32_t sedi_i2c_control(IN sedi_i2c_t i2c_device, IN uint32_t control, IN uint3
 	case SEDI_I2C_SET_RX_MEMORY_TYPE:
 		context->rx_memory_type = arg;
 		break;
+	case SEDI_I2C_SET_BUS_DATA_STD:
+	case SEDI_I2C_SET_BUS_DATA_FST:
+	case SEDI_I2C_SET_BUS_DATA_FSP:
+	case SEDI_I2C_SET_BUS_DATA_HIGH:
+		{
+			const sedi_i2c_bus_clk_t *bus_clk = (const sedi_i2c_bus_clk_t *)arg;
+			sedi_i2c_bus_clk_t *bus_clk_ptr = &context->bus_info.std_clk;
+			uint32_t idx = control - SEDI_I2C_SET_BUS_DATA_STD;
+
+			DBG_CHECK(NULL != bus_clk, SEDI_DRIVER_ERROR_PARAMETER);
+			DBG_CHECK(idx <  sizeof(context->bus_info) / sizeof(sedi_i2c_bus_clk_t),
+					SEDI_DRIVER_ERROR_PARAMETER);
+
+			bus_clk_ptr = bus_clk_ptr + idx;
+			bus_clk_ptr->sda_hold = LBW_CLK_MHZ * bus_clk->sda_hold / NS_PER_US;
+			bus_clk_ptr->hcnt = LBW_CLK_MHZ * bus_clk->hcnt / NS_PER_US;
+			bus_clk_ptr->lcnt = LBW_CLK_MHZ * bus_clk->lcnt / NS_PER_US;
+		}
+		break;
 	default:
 		ret = SEDI_DRIVER_ERROR;
 		break;

--- a/bsp_sedi/include/driver/sedi_driver_i2c.h
+++ b/bsp_sedi/include/driver/sedi_driver_i2c.h
@@ -67,6 +67,19 @@ extern "C" {
 #define SEDI_I2C_SET_RX_MEMORY_TYPE (0x06)
 
 /*!
+ * \def SEDI_I2C_SET_BUS_DATA_STD/_FST/_FSP/_HIGH
+ * \brief Update cached bus timing data for a speed mode.
+ *
+ * The new timing values are stored in the driver context and take effect
+ * the next time the corresponding bus speed is selected through
+ * SEDI_I2C_BUS_SPEED.
+ */
+#define SEDI_I2C_SET_BUS_DATA_STD (0x0B)
+#define SEDI_I2C_SET_BUS_DATA_FST (SEDI_I2C_SET_BUS_DATA_STD + 1)
+#define SEDI_I2C_SET_BUS_DATA_FSP (SEDI_I2C_SET_BUS_DATA_STD + 2)
+#define SEDI_I2C_SET_BUS_DATA_HIGH (SEDI_I2C_SET_BUS_DATA_STD + 3)
+
+/*!
  * \}
  */
 


### PR DESCRIPTION
Add 4 new control SEDI_I2C_SET_BUS_DATA_XXX comands to runtime update cached I2C bus timing values set defaultly.
This enables board-specific timing calibration.