### PR TITLE
aon: Clean up SRAM deep-sleep entry/exit sequencing

### DIFF
--- a/bsp_sedi/soc/intel_ish/pm/aon/ish_aontask.c
+++ b/bsp_sedi/soc/intel_ish/pm/aon/ish_aontask.c
@@ -613,8 +613,6 @@ static void sram_enter_sleep_mode(void)
 #else
 	for (int i = 0; i < SRAM_POWER_OFF_BANKS; i++) {
 		BANK_DS_ENABLE(i);
-		while (BANK_PWR_STATUS(i))
-			;
 	}
 #endif
 }
@@ -644,11 +642,9 @@ static void sram_exit_sleep_mode(void)
 	}
 #else
 	for (int i = 0; i < SRAM_POWER_OFF_BANKS; i++) {
-		if (!BANK_PWR_STATUS(i)) {
-			BANK_DS_DISABLE(i);
-			delay(RETENTION_EXIT_CYCLES_DELAY);
-			while (!BANK_PWR_STATUS(i))
-				;
+		BANK_DS_DISABLE(i);
+		delay(RETENTION_EXIT_CYCLES_DELAY);
+		while (!BANK_PWR_STATUS(i)) {
 		}
 	}
 #endif


### PR DESCRIPTION
Enhance SRAM retention handling so the same flow works across more ISH variants.
- Drop the BANK_PWR_STATUS() spin loop after BANK_DS_ENABLE. No risk as there's already a global delay out of this helper.
- The previous status guard was unnecessary and could skip required restore steps on some variants.